### PR TITLE
build: Fix an error that fails to find ls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 ifeq ($(CXX),)
 CXX ?= g++
 endif
-LIBDIR := $(shell echo -n lib; (ldd /usr/bin/ls |grep -q lib64) && echo -n 64)
+LIBDIR := $(shell echo -n lib; (`which ls` | grep -q lib64) && echo -n 64)
 endif
 SRCDIR ?= $(CURDIR)
 OBJDIR ?= $(CURDIR)/build/$(shell $(CXX) -dumpmachine)/$(shell $(CXX) -dumpversion)


### PR DESCRIPTION
Since the path of "ls" can be platform dependent, it'd be better not to
specifiy its absolute path.
```
  $ make
  ldd: /usr/bin/ls: No such file or directory
  g++ -Ilibleaktracer/include -Ilibleaktracer/src -DUSE_BACKTRACE ...
  g++ -Ilibleaktracer/include -Ilibleaktracer/src -DUSE_BACKTRACE ...
     ...
```
This patch is to fix the error above.