### PR TITLE
helper: Fix leak-check execution

### DIFF
--- a/helpers/leak-check
+++ b/helpers/leak-check
@@ -82,4 +82,4 @@ fi
 
 # run the program
 export LD_PRELOAD="$LEAKTRACER_SHARED_LIB"
-exec $@
+exec "$@"


### PR DESCRIPTION
In some cases, leak-check cannot pass the target execution parameters in
its original form.  In some cases, the execution might be failed as
follows:
```
  $ leak-check node -e ''
  LeakTracer 3.0.0 (shared library) -- LGPLv2
  node: -e requires an argument
```
If leak-check is not used, it executes normally.